### PR TITLE
Replace Get Started button with GetYourGuide widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
                         <h2 class="text-white mt-0">Seine River Cruises</h2>
                         <hr class="divider divider-light" />
                         <p class="text-white-75 mb-4">This scenic Seine River cruise is a favorite among travelers for its stunning views, excellent reviews, and unique Paris experience. Reserve your spot today or explore more tours listed below.</p>
-                        <a class="btn btn-light btn-xl" href="#history">Get Started!</a>
+                        <div data-gyg-href="https://widget.getyourguide.com/default/availability.frame" data-gyg-tour-id="409183" data-gyg-locale-code="en-US" data-gyg-currency="EUR" data-gyg-widget="availability" data-gyg-variant="auto" data-gyg-partner-id="X3LLOUG"><span>Powered by <a target="_blank" rel="sponsored" href="https://www.getyourguide.com/paris-l16/">GetYourGuide</a></span></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- swap the Get Started! button for the GetYourGuide widget snippet on the home page

## Testing
- `npx --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5f36324c8322af54e685bccda6ac