### PR TITLE
Add historic Seine section

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
                 </div>
             </div>
         </section>
-        <!-- History-->
-        <section class="page-section" id="history">
+        <!-- Recommended Cruises-->
+        <section class="page-section" id="tours">
             <div class="container px-4 px-lg-5">
                 <h2 class="text-center mt-0">Best Seine River Cruises to Book in Paris</h2>
                 <hr class="divider" />
@@ -151,11 +151,26 @@
                 </div>
             </div>
         </div>
-        <!-- Call to action-->
-        <section class="page-section bg-dark text-white">
-            <div class="container px-4 px-lg-5 text-center">
-                <h2 class="mb-4">Free Download at Start Bootstrap!</h2>
-                <a class="btn btn-light btn-xl" href="https://startbootstrap.com/theme/creative/">Download Now!</a>
+        <!-- History Section -->
+        <section id="history" class="page-section history-section">
+            <div class="container">
+                <h2>🏛️ History of the Seine: the river that gave life to Paris</h2>
+                <p>There’s more to the <strong>Seine River</strong> than just a symbol of Paris. It’s the <strong>historic and cultural lifeblood of France</strong>. Stretching <strong>775 kilometers</strong>, it begins in <strong>Burgundy</strong> and flows through northern France until it reaches the <strong>English Channel at Le Havre</strong>.</p>
+                <p>For nearly two millennia, starting with the <strong>Roman Empire</strong>, the Seine played a vital role in the rise of <strong>Lutetia</strong>, the ancient name of Paris. It offered a natural path for <strong>trade</strong>, <strong>defense</strong>, and <strong>growth</strong>, eventually turning its banks into the city’s core. Landmarks like <strong>Notre-Dame (1163)</strong>, <strong>Pont Neuf (1607)</strong>, and the <strong>Eiffel Tower (1889)</strong> rose along its shores.</p>
+                <p>Today, the <strong>Seine cuts through Paris</strong>, crossed by <strong>37 iconic bridges</strong> that connect the <strong>Left Bank (Rive Gauche)</strong> to the <strong>Right Bank (Rive Droite)</strong>, and link the islands of <strong>Île de la Cité</strong> and <strong>Île Saint-Louis</strong>, the birthplace of Paris. Each bridge has its own story:</p>
+                <ul>
+                    <li><strong>Pont Neuf</strong>, the oldest, despite its name meaning “New Bridge”</li>
+                    <li><strong>Pont Alexandre III</strong>, the most ornate, built for the 1900 World’s Fair</li>
+                    <li><strong>Pont des Arts</strong>, once filled with love locks, a romantic favorite</li>
+                    <li><strong>Pont de Bir-Hakeim</strong>, known for its iron design and Eiffel Tower views</li>
+                    <li><strong>Pont Marie</strong>, built in the 17th century and still in use today</li>
+                </ul>
+                <p>Across France, the Seine is crossed by more than <strong>300 bridges</strong>, but nowhere is its beauty more alive than in <strong>Paris</strong>, where it becomes a blend of <strong>history, elegance</strong>, and <strong>postcard-worthy scenes</strong>.</p>
+                <p>📝 Since <strong>1991</strong>, the banks of the Seine in Paris have been recognized as a <strong>UNESCO World Heritage Site</strong>, thanks to their exceptional concentration of landmarks.</p>
+                <p>🚤 A <strong>Seine River cruise</strong> is more than sightseeing. It’s a journey through the city’s soul, one ripple at a time.</p>
+                <p>🚣‍♀️ See the city’s past from the river: explore our <strong>curated Seine cruises</strong> with <strong>panoramic views</strong> and <strong>romantic sunset rides</strong> that bring the river's story to life.</p>
+                <p>🛎️ Choose from our selection of <strong>hotels along the Seine</strong>, hand-picked to give you the full experience of staying in the heart of Paris.</p>
+                <p>👉 <strong>Book now</strong> and start your journey through the <strong>living history of the Seine</strong>.</p>
             </div>
         </section>
         <!-- Contact-->


### PR DESCRIPTION
## Summary
- rename old `#history` block to `#tours`
- insert Seine history section in place of "Free Download" call to action

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c8be3b46883229d8d962ee7763b18