### PR TITLE
Fix footer underline placement

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11006,26 +11006,30 @@ header.masthead h1, header.masthead .h1 {
   letter-spacing: 1px;
   position: relative;
   padding-bottom: 8px;
+  display: inline-block;
 }
 .site-footer h3::after {
   content: "";
-  display: block;
-  width: 50px;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
   height: 2px;
   background-color: #ffffff;
-  margin: 0.5rem auto 0;
 }
 .site-footer h5 {
   position: relative;
   padding-bottom: 8px;
+  display: inline-block;
 }
 .site-footer h5::after {
   content: "";
-  display: block;
-  width: 50px;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
   height: 2px;
   background-color: #ffffff;
-  margin: 0 auto;
 }
 .site-footer a {
   color: #ffffff;


### PR DESCRIPTION
## Summary
- adjust footer header pseudo-elements for proper underlining

## Testing
- `w3m -dump index.html | grep -n -A3 "About Us" -B1`

------
https://chatgpt.com/codex/tasks/task_e_686dd41068048322823cb5d05ebb736e