### PR TITLE
Remove footer title underline

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11008,15 +11008,6 @@ header.masthead h1, header.masthead .h1 {
   padding-bottom: 8px;
   display: inline-block;
 }
-.site-footer h3::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 2px;
-  background-color: #ffffff;
-}
 .site-footer h5 {
   position: relative;
   padding-bottom: 8px;


### PR DESCRIPTION
## Summary
- drop CSS rules that added an underline effect to `.site-footer h3`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686dd60c20148322908fcd9363ec85c4