### PR TITLE
Fix hero section on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10935,6 +10935,13 @@ header.masthead {
   background-attachment: scroll;
   background-size: cover;
 }
+
+@media (max-width: 991.98px) {
+  header.masthead {
+    background-position: center;
+    height: 100vh;
+  }
+}
 header.masthead h1, header.masthead .h1 {
   font-size: 2.25rem;
 }


### PR DESCRIPTION
## Summary
- ensure the hero background remains centered on mobile
- give the masthead a full-screen height on small screens

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686de3e91f50832282f8c74351c91854