### PR TITLE
Align backgrounds in page sections

### DIFF
--- a/best-seine-cruises.html
+++ b/best-seine-cruises.html
@@ -72,7 +72,7 @@
         </section>
 
         <!-- Section: recommended cruise widgets -->
-        <section class="page-section bg-light" id="recommended">
+        <section class="page-section bg-white" id="recommended">
             <div class="container px-4 px-lg-5">
                 <h2 class="text-center mt-0">Best Seine Cruises You Can Book Today</h2>
                 <hr class="divider" />
@@ -141,7 +141,7 @@
         </section>
 
         <!-- Section: why we chose these cruises -->
-        <section id="why-picks" class="page-section bg-white">
+        <section id="why-picks" class="page-section bg-light">
         <div class="container">
         <h2 class="h4 mb-4">Why We Picked These 5 Cruises</h2>
         <p>
@@ -157,7 +157,7 @@
         </section>
 
         <!-- Section: quick comparison table -->
-        <section id="comparison" class="page-section">
+        <section id="comparison" class="page-section bg-white">
         <div class="container">
         <h2 class="text-center mb-4">Quick Comparison of the Top 5 Seine Cruises</h2>
         <div class="table-responsive">
@@ -354,7 +354,7 @@
         </section>
 
         <!-- Section: detailed reviews for each cruise -->
-        <section id="detailed-reviews" class="page-section bg-light">
+        <section id="detailed-reviews" class="page-section bg-white">
         <div class="container">
         <h2 class="mb-4 mt-5 text-center">Detailed Reviews of the Top Seine Cruises in Paris</h2>
         <div class="card mb-5 shadow-sm border-0">
@@ -487,7 +487,7 @@
         </section>
 
         <!-- Section: frequently asked questions -->
-        <section id="faqs" class="page-section">
+        <section id="faqs" class="page-section bg-light">
         <div class="container">
         <h2 class="text-center mb-4">FAQs about Seine River Cruises</h2>
         <div class="accordion" id="seineCruiseFAQs">

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
             </div>
         </section>
         <!-- Recommended Cruises-->
-        <section class="page-section" id="tours">
+        <section class="page-section bg-white" id="tours">
             <div class="container px-4 px-lg-5">
                 <h2 class="text-center mt-0">Best Seine River Cruises to Book in Paris</h2>
                 <hr class="divider" />
@@ -161,7 +161,7 @@
             </div>
         </div>
         <!-- History Section -->
-        <section id="history" class="page-section history-section">
+        <section id="history" class="page-section bg-light history-section">
             <div class="container">
                 <h2>🏛️ History of the Seine: the river that gave life to Paris</h2>
                 <p>There’s more to the <strong>Seine River</strong> than just a symbol of Paris. It’s the <strong>historic and cultural lifeblood of France</strong>. Stretching <strong>775 kilometers</strong>, it begins in <strong>Burgundy</strong> and flows through northern France until it reaches the <strong>English Channel at Le Havre</strong>.</p>

--- a/privacy.html
+++ b/privacy.html
@@ -54,7 +54,7 @@
             </div>
         </header>
         <!-- Privacy Policy-->
-        <section class="page-section" id="Privacy Policy">
+        <section class="page-section bg-primary" id="Privacy Policy">
             <div class="container px-4 px-lg-5">
                 <p class="text-muted mb-4">At Seine.travel, we respect your privacy. This website uses Google Analytics 4 to collect anonymous data such as page views, clicks, device type, and country of origin. This data helps us understand how visitors use the site and improve your experience.</p>
                 <p class="text-muted mb-4">We do <strong>not</strong> collect personally identifiable information. No forms, names, emails, or payment details are collected or stored on this site.</p>


### PR DESCRIPTION
## Summary
- set up alternating backgrounds across sections on index
- align section backgrounds on best-seine-cruises page
- start privacy section with primary background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877034a1678832283372c91ce8a7e43